### PR TITLE
Add --in-namespace option

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,27 @@
+steps:
+  - label: Lint
+    command:
+      - bundle install
+      - bundle exec rubocop
+    agents:
+      queue: 'chef'
+
+  - label: Rspec
+    command:
+      - bundle install
+      - bundle exec rspec
+    agents:
+      queue: 'chef'
+
+  - label: Publish
+    env:
+      REPO_SERVER: gems.sendgrid.net
+    branches: 'master'
+    command:
+      - bundle install
+      - bundle exec rake build
+      - mkdir -p ci-repo
+      - cp pkg/* ci-repo/
+      - workflow publish_package_legacy
+    agents:
+      queue: 'chef'

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Usage: check-kube-pods-pending.rb (options)
         --token-file TOKEN-FILE      File containing bearer token for authorization
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
+        --in-namespace               If running in K8S, operate in running namespace
     -n NAMESPACES,                   Exclude the specified list of namespaces
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
@@ -90,6 +91,7 @@ Usage: check-kube-service-available.rb (options)
         --token-file TOKEN-FILE      File containing bearer token for authorization
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
+        --in-namespace               If running in K8S, operate in running namespace
     -p, --pending SECONDS            Time (in seconds) a pod may be pending for and be valid
     -l, --list SERVICES              List of services to check (required)
         --kube-config KUBECONFIG     Path to a kube config file
@@ -108,6 +110,7 @@ Usage: check-kube-pods-runtime.rb (options)
         --token-file TOKEN-FILE      File containing bearer token for authorization
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
+        --in-namespace               If running in K8S, operate in running namespace
     -c, --critical COUNT             Threshold for Pods to be critical
     -f, --filter FILTER              Label selector for pods to be checked (example -- key1=value1,key2!=value2)
     -p, --pods PODS                  List of pods to check
@@ -128,6 +131,7 @@ Usage: ./check-kube-pods-running.rb (options)
         --token-file TOKEN-FILE      File containing bearer token for authorization
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
+        --in-namespace               If running in K8S, operate in running namespace
     -n NAMESPACES,                   Exclude the specified list of namespaces
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
@@ -151,6 +155,7 @@ Usage: ./check-kube-pods-restarting.rb (options)
         --token-file TOKEN-FILE      File containing bearer token for authorization
     -u, --user USER                  User with access to API
     -v, --api-version VERSION        API version
+        --in-namespace               If running in K8S, operate in running namespace
     -n NAMESPACES,                   Exclude the specified list of namespaces
         --exclude-namespace
     -i NAMESPACES,                   Include the specified list of namespaces, an 
@@ -194,12 +199,13 @@ Usage: metrics-pods.rb (options)
         --key KEY-FILE               Client key for the client cert
         --in-cluster                 Use service account authentication
         --password PASSWORD          If user is passed, also pass a password
-        -s, --api-server URL             URL to API server
-        -t, --token TOKEN                Bearer token for authorization
+    -s, --api-server URL             URL to API server
+    -t, --token TOKEN                Bearer token for authorization
         --token-file TOKEN-FILE      File containing bearer token for authorization
-        -u, --user USER                  User with access to API
-        -v, --api-version VERSION        API version
-            --kube-config KUBECONFIG     Path to a kube config file
+    -u, --user USER                  User with access to API
+    -v, --api-version VERSION        API version
+        --kube-config KUBECONFIG     Path to a kube config file
+        --in-namespace               If running in K8S, operate in running namespace
 ```
 
 `api_server` and `api_version` can still be used for backwards compatibility,

--- a/bin/check-kube-pods-pending.rb
+++ b/bin/check-kube-pods-pending.rb
@@ -26,6 +26,7 @@
 #     --password PASSWORD          If user is passed, also pass a password
 #     --token TOKEN                Bearer token for authorization
 #     --token-file TOKEN-FILE      File containing bearer token for authorization
+#     --in-namespace               If running in K8S, operate in running namespace
 # -n NAMESPACES,                   Exclude the specified list of namespaces
 #     --exclude-namespace
 # -i NAMESPACES,                   Include the specified list of namespaces, an
@@ -46,9 +47,10 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/cli/namespaced'
 
 class AllPodsAreReady < Sensu::Plugins::Kubernetes::CLI
-  @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::NamespacedCLI
 
   option :pod_list,
          description: 'List of pods to check',
@@ -88,9 +90,9 @@ class AllPodsAreReady < Sensu::Plugins::Kubernetes::CLI
     pods = []
     if config[:label_filter].nil?
       pods_list = parse_list(config[:pod_list])
-      pods = client.get_pods
+      pods = client.get_pods(namespace: namespace)
     else
-      pods = client.get_pods(label_selector: config[:label_filter].to_s)
+      pods = client.get_pods(namespace: namespace, label_selector: config[:label_filter].to_s)
       if pods.empty?
         unknown 'The filter specified resulted in 0 pods'
       end

--- a/bin/check-kube-pods-restarting.rb
+++ b/bin/check-kube-pods-restarting.rb
@@ -26,6 +26,7 @@
 #        --token-file TOKEN-FILE      File containing bearer token for authorization
 #    -u, --user USER                  User with access to API
 #    -v, --api-version VERSION        API version
+#        --in-namespace               If running in K8S, operate in running namespace
 #    -n NAMESPACES,                   Exclude the specified list of namespaces
 #        --exclude-namespace
 #    -i NAMESPACES,                   Include the specified list of namespaces, an
@@ -45,9 +46,10 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/cli/namespaced'
 
 class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
-  @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::NamespacedCLI
 
   option :pod_list,
          description: 'List of pods to check',
@@ -87,9 +89,9 @@ class PodsRestarting < Sensu::Plugins::Kubernetes::CLI
     pods = []
     if config[:label_filter].nil?
       pods_list = parse_list(config[:pod_list])
-      pods = client.get_pods
+      pods = client.get_pods(namespace: namespace)
     else
-      pods = client.get_pods(label_selector: config[:label_filter].to_s)
+      pods = client.get_pods(namespace: namespace, label_selector: config[:label_filter].to_s)
       if pods.empty?
         unknown 'The filter specified resulted in 0 pods'
       end

--- a/bin/check-kube-pods-running.rb
+++ b/bin/check-kube-pods-running.rb
@@ -26,6 +26,7 @@
 #         --token-file TOKEN-FILE      File containing bearer token for authorization
 #     -u, --user USER                  User with access to API
 #     -v, --api-version VERSION        API version
+#         --in-namespace               If running in K8S, operate in running namespace
 #     -n NAMESPACES,                   Exclude the specified list of namespaces
 #         --exclude-namespace
 #     -i NAMESPACES,                   Include the specified list of namespaces, an
@@ -43,9 +44,10 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/cli/namespaced'
 
 class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
-  @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::NamespacedCLI
 
   option :pod_list,
          description: 'List of pods to check',
@@ -78,9 +80,9 @@ class AllPodsAreRunning < Sensu::Plugins::Kubernetes::CLI
     pods = []
     if config[:label_filter].nil?
       pods_list = parse_list(config[:pod_list])
-      pods = client.get_pods
+      pods = client.get_pods(namespace: namespace)
     else
-      pods = client.get_pods(label_selector: config[:label_filter].to_s)
+      pods = client.get_pods(namespace: namespace, label_selector: config[:label_filter].to_s)
       if pods.empty?
         unknown 'The filter specified resulted in 0 pods'
       end

--- a/bin/check-kube-pods-runtime.rb
+++ b/bin/check-kube-pods-runtime.rb
@@ -26,6 +26,7 @@
 #     --password PASSWORD          If user is passed, also pass a password
 #     --token TOKEN                Bearer token for authorization
 #     --token-file TOKEN-FILE      File containing bearer token for authorization
+#     --in-namespace               If running in K8S, operate in running namespace
 # -c, --critical COUNT             Threshold for Pods to be critical
 # -f, --filter FILTER              Selector filter for pods to be checked
 # -p, --pods PODS                  List of pods to check
@@ -38,9 +39,10 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/cli/namespaced'
 
 class PodRuntime < Sensu::Plugins::Kubernetes::CLI
-  @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::NamespacedCLI
 
   option :pod_list,
          description: 'List of pods to check',
@@ -74,9 +76,9 @@ class PodRuntime < Sensu::Plugins::Kubernetes::CLI
 
     if config[:label_filter].nil?
       pods_list = parse_list(config[:pod_list])
-      pods = client.get_pods
+      pods = client.get_pods(namespace: namespace)
     else
-      pods = client.get_pods(label_selector: config[:label_filter].to_s)
+      pods = client.get_pods(namespace: namespace, label_selector: config[:label_filter].to_s)
       pods_list = ['all']
     end
 

--- a/bin/check-kube-service-available.rb
+++ b/bin/check-kube-service-available.rb
@@ -26,6 +26,7 @@
 #     --password PASSWORD          If user is passed, also pass a password
 #     --token TOKEN                Bearer token for authorization
 #     --token-file TOKEN-FILE      File containing bearer token for authorization
+#     --in-namespace               If running in K8S, operate in running namespace
 # -l, --list SERVICES              List of services to check (required)
 # -p, --pending SECONDS            Time (in seconds) a pod may be pending for and be valid
 #
@@ -38,10 +39,11 @@
 #
 
 require 'sensu-plugins-kubernetes/cli'
+require 'sensu-plugins-kubernetes/cli/namespaced'
 require 'time'
 
 class AllServicesUp < Sensu::Plugins::Kubernetes::CLI
-  @options = Sensu::Plugins::Kubernetes::CLI.options.dup
+  include Sensu::Plugins::Kubernetes::NamespacedCLI
 
   option :service_list,
          description: 'List of services to check',
@@ -59,7 +61,8 @@ class AllServicesUp < Sensu::Plugins::Kubernetes::CLI
   def run
     services = parse_list(config[:service_list])
     failed_services = []
-    s = client.get_services
+    s = client.get_services(namespace: namespace)
+    # rubocop:disable Metrics/BlockLength
     s.each do |a|
       next unless services.include?(a.metadata.name)
       # Build the selector key so we can fetch the corresponding pod
@@ -71,7 +74,7 @@ class AllServicesUp < Sensu::Plugins::Kubernetes::CLI
       # Get the pod
       pod = nil
       begin
-        pod = client.get_pods(label_selector: selector_key.join(',').to_s)
+        pod = client.get_pods(namespace: namespace, label_selector: selector_key.join(',').to_s)
       rescue
         failed_services << a.metadata.name.to_s
       end
@@ -99,6 +102,7 @@ class AllServicesUp < Sensu::Plugins::Kubernetes::CLI
         failed_services << "#{p.metadata.namespace}.#{p.metadata.name}" if pod_available == false
       end
     end
+    # rubocop:enable Metrics/BlockLength
 
     if failed_services.empty? && services.empty?
       ok 'All services are reporting as up'

--- a/lib/sensu-plugins-kubernetes/cli/namespaced.rb
+++ b/lib/sensu-plugins-kubernetes/cli/namespaced.rb
@@ -1,0 +1,60 @@
+module Sensu
+  module Plugins
+    # Namespace for the Kubernetes sensu-plugin.
+    module Kubernetes
+      # Allows checks to easily retrieve a kube-client compatible namespace
+      # string, and provide flags allowing users to configure this operation.
+      module NamespacedCLI
+        # The location of the service account namespace file.
+        INCLUSTER_NAMESPACE_FILE =
+          '/var/run/secrets/kubernetes.io/serviceaccount/namespace'.freeze
+
+        # On inclusion, add options to the including class. This is done because
+        # the "option" method is a class method.
+        def self.included(base)
+          base.send(:option,
+                    :in_namespace,
+                    description: 'Operate in the namespace of the pod running the check (when running in-cluster)',
+                    long: '--in-namespace',
+                    boolean: true,
+                    default: false)
+        end
+
+        # Smart getter for the namespace string queries should be using.
+        def namespace
+          @namespace ||= determine_namespace
+        end
+
+        private
+
+        # If "--in-namespace" is specified, get our pod's namespace. Otherwise,
+        # perform cluster-wide requests.
+        def determine_namespace
+          # By default, perform cluster-wide requests
+          return '' unless config[:in_namespace]
+
+          begin
+            namespace = File.read(INCLUSTER_NAMESPACE_FILE).strip
+            unless valid_namespace?(namespace)
+              raise "invalid namespace '#{namespace}' found in #{INCLUSTER_NAMESPACE_FILE}"
+            end
+          rescue StandardError => e
+            raise e, "Unable to determine namespace: #{e}", e.backtrace
+          end
+
+          namespace
+        end
+
+        # Test if a string (ns) is a valid Kubernetes namespace name. Per the
+        # docs below, this means a string of 1-63 lower case alphanumeric
+        # characters or hyphens, as long as the first character is not a hyphen:
+        # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md#definitions
+        def valid_namespace?(ns)
+          # rubocop:disable Style/DoubleNegation
+          !!(/[a-z0-9][a-z0-9-]{,62}/ =~ ns)
+          # rubocop:enable Style/DoubleNegation
+        end
+      end
+    end
+  end
+end

--- a/lib/sensu-plugins-kubernetes/version.rb
+++ b/lib/sensu-plugins-kubernetes/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsKubernetes
   module Version
     MAJOR = 3
-    MINOR = 0
-    PATCH = 1
+    MINOR = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sendgrid-sensu-plugins-kubernetes.gemspec
+++ b/sendgrid-sensu-plugins-kubernetes.gemspec
@@ -4,13 +4,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require_relative 'lib/sensu-plugins-kubernetes'
 
+# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
   s.date                   = Date.today.to_s
-  s.description            = 'Provides monitoring for Kubernetes via Sensu'
+  s.description            = 'Provides monitoring for Kubernetes via Sensu (SendGrid Fork)'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md Gemfile sendgrid-sensu-plugins-kubernetes.gemspec)
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-kubernetes'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -18,12 +19,12 @@ Gem::Specification.new do |s|
                                'production_status'  => 'unstable - testing recommended',
                                'release_draft'      => 'false',
                                'release_prerelease' => 'false' }
-  s.name                   = 'sensu-plugins-kubernetes'
+  s.name                   = 'sendgrid-sensu-plugins-kubernetes'
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
   s.required_ruby_version  = '>= 2.1.0'
-  s.summary                = 'Sensu plugins for kubernetes'
+  s.summary                = 'Sensu plugins for kubernetes (SendGrid fork)'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsKubernetes::Version::VER_STRING
 
@@ -41,3 +42,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
# Summary
[OPSENG-1489](https://jira.sendgrid.net/browse/OPSENG-1489): The main change here is adding an `--in-namespace` flag to all checks that can be scoped to a namespace (those operating on pods and services). This is done by creating a `NamespacedCLI` mixin included by the checks, to prevent code duplication. I may go back later and add the other namespace-related options to it later. Additionally, this change add a Buildkite pipeline to build and publish the gem.