### PR TITLE
Use v2.0+ of sensu-plugins

### DIFF
--- a/lib/sensu-plugins-kubernetes/version.rb
+++ b/lib/sensu-plugins-kubernetes/version.rb
@@ -1,7 +1,7 @@
 module SensuPluginsKubernetes
   module Version
     MAJOR = 3
-    MINOR = 1
+    MINOR = 2
     PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')

--- a/sendgrid-sensu-plugins-kubernetes.gemspec
+++ b/sendgrid-sensu-plugins-kubernetes.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsKubernetes::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',   '~> 2.0'
   s.add_runtime_dependency 'kubeclient',     '~> 2.3'
   s.add_runtime_dependency 'activesupport',  '< 5.0.0'
 


### PR DESCRIPTION
[https://jira.sendgrid.net/browse/OPSENG-1516](https://jira.sendgrid.net/browse/OPSENG-1516): Versions of sensu using `ruby >= 2.4` need to use `sensu-plugins >= 2.0` to support `json >= 2.0`. I tested this on kubemaster0004t1mdw1.sendgrid.net without issue.